### PR TITLE
Disable streaming for pylons requests, fixes ckan/ckan#4431

### DIFF
--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -134,10 +134,7 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
     )
 
     # Establish the Registry for this application
-    # The RegistryManager includes code to pop
-    # registry values after the stream has completed,
-    # so we need to prevent this with `streaming` set to True.
-    app = RegistryManager(app, streaming=True)
+    app = RegistryManager(app, streaming=False)
 
     if asbool(static_files):
         # Serve static files


### PR DESCRIPTION
## What
Cherry picks [this commit](https://github.com/ckan/ckan/commit/42713323bf2f54cf3529f52415c2a910ea99db7d).

## Why
This fixes an issue that we've been seeing whilst running visual regression tests involving an assertion error.

**Card:** https://trello.com/c/oOGsqjx4/167-pylons-error-assertionerror-popped-wrong-app-context