### PR TITLE
solr: add support for multicore solr installations by changing expected SOLR_SCHEMA_FILE_OFFSET

### DIFF
--- a/ckan/lib/search/__init__.py
+++ b/ckan/lib/search/__init__.py
@@ -55,7 +55,7 @@ _QUERIES = {
     'package': PackageSearchQuery
 }
 
-SOLR_SCHEMA_FILE_OFFSET = '/admin/file/?file=schema.xml'
+SOLR_SCHEMA_FILE_OFFSET = '/schema?wt=schema.xml'
 
 
 def _normalize_type(_type):


### PR DESCRIPTION
https://trello.com/c/kNCMduAg/229-can-ckan-be-convinced-to-run-on-a-multicore-solr

Upstream 2.9 has a more complete solution to this https://github.com/ckan/ckan/pull/4536 which I don't want to port across. Luckily the `/schema?wt=schema.xml` url seems to work on both single core and multi-core installations, so we may be able to apply this to our 2.7 branch too and do away with needing two separate `solr` configurations on our boxes.