### PR TITLE
PackageSearchIndex.index_package(): catch IndexError from date parsing

### DIFF
--- a/ckan/lib/search/index.py
+++ b/ckan/lib/search/index.py
@@ -242,7 +242,7 @@ class PackageSearchIndex(SearchIndex):
                         # The date field was empty, so dateutil filled it with
                         # the default bogus date
                         value = None
-                except ValueError:
+                except (ValueError, IndexError):
                     continue
             new_dict[key] = value
         pkg_dict = new_dict


### PR DESCRIPTION
https://trello.com/c/OxoHouSW

The date parser is liable to raise `IndexError` due to https://github.com/dateutil/dateutil/issues/1071, so catch/ignore that in the same way as `ValueError` until `dateutil` is fixed.
