### PR TITLE
Merge pull request from GHSA-2772-p3f3-5x24

### DIFF
--- a/ckan/config/middleware/common_middleware.py
+++ b/ckan/config/middleware/common_middleware.py
@@ -91,3 +91,20 @@ class TrackingMiddleware(object):
             self.engine.execute(sql, key, data.get('url'), data.get('type'))
             return []
         return self.app(environ, start_response)
+
+
+class HostHeaderMiddleware(object):
+    '''
+        Prevent the `Host` header from the incoming request to be used
+        in the `Location` header of a redirect.
+    '''
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        path_info = environ[u'PATH_INFO']
+        if path_info in ['/login_generic', '/user/login',
+                         '/user/logout', '/user/logged_in',
+                         '/user/logged_out']:
+            environ.pop('HTTP_HOST', None)
+        return self.app(environ, start_response)

--- a/ckan/config/middleware/flask_app.py
+++ b/ckan/config/middleware/flask_app.py
@@ -28,6 +28,7 @@ from ckan.lib import jinja_extensions
 from ckan.lib import uploader
 from ckan.lib import i18n
 from ckan.common import config, g, request, ungettext
+from ckan.config.middleware.common_middleware import HostHeaderMiddleware
 import ckan.lib.app_globals as app_globals
 from ckan.plugins import PluginImplementations
 from ckan.plugins.interfaces import IBlueprint, IMiddleware, ITranslation
@@ -263,6 +264,9 @@ def make_flask_stack(conf, **app_conf):
     flask_config_keys = set(flask_app.config.keys()) - set(config.keys())
     for key in flask_config_keys:
         config[key] = flask_app.config[key]
+
+    # Prevent the host from request to be added to the new header location.
+    app = HostHeaderMiddleware(app)
 
     # Add a reference to the actual Flask app so it's easier to access
     app._wsgi_app = flask_app

--- a/ckan/config/middleware/pylons_app.py
+++ b/ckan/config/middleware/pylons_app.py
@@ -171,6 +171,8 @@ def make_pylons_stack(conf, full_stack=True, static_files=True,
                 )
         app = Cascade(extra_static_parsers + static_parsers)
 
+    # Prevent the host from request to be added to the new header location.
+    app = common_middleware.HostHeaderMiddleware(app)
     # Tracking
     if asbool(config.get('ckan.tracking_enabled', 'false')):
         app = common_middleware.TrackingMiddleware(app, config)


### PR DESCRIPTION
[x]: Handle host in request to be added to the new header location

This PR cherry picks a commit from upstream CKAN that isn't available in our current version of CKAN to fix a recent incident where the `Host` header can be used to expose an open redirect vulnerability.

[Trello Card](https://trello.com/c/oRVFNc2T/2107-5-investigate-fix-open-redirect-by-host-header-vulnerability-using-nginx)